### PR TITLE
CI: migrate to fly.io for hosting the demo endpoint

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,16 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+

--- a/endpoint/Dockerfile
+++ b/endpoint/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1 as builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+
+FROM debian:buster-slim as runner
+
+RUN useradd -ms /bin/bash app
+
+USER app
+WORKDIR /app
+
+COPY --from=builder /app/target/release/bootstrap /app/pathfinder-api
+
+ENV ROCKET_ADDRESS=0.0.0.0
+ENV ROCKET_SECRET_KEY=
+ENV ROCKET_PORT=8000
+
+EXPOSE 8000
+
+CMD ["./pathfinder-api"]

--- a/endpoint/fly.toml
+++ b/endpoint/fly.toml
@@ -17,10 +17,6 @@ kill_timeout = "5s"
   internal_port = 8000
 
   [[services.ports]]
-    port = 80
-    handlers = ["http"]
-
-  [[services.ports]]
     port = 443
     handlers = ["tls", "http"]
   [services.concurrency]

--- a/endpoint/fly.toml
+++ b/endpoint/fly.toml
@@ -1,0 +1,35 @@
+# fly.toml app configuration file generated for pathfinder-api-stable on 2023-05-04T01:03:11+02:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "pathfinder-api-stable"
+primary_region = "ams"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+[env]
+  PORT = "8000"
+  PRIMARY_REGION = "ams"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8000
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "1s"
+    restart_limit = 6


### PR DESCRIPTION
1. adds fly.io support files
2. configures GH action to automatically deploy `main` to fly.io