### PR TITLE
chore: allow renamed_and_removed_lints

### DIFF
--- a/endpoint/src/api_types.rs
+++ b/endpoint/src/api_types.rs
@@ -5,6 +5,9 @@
  * LICENSE file in the crate's root directory of this source tree.
  */
 //! Use Case 001 REST API-related type definitions
+
+#![allow(renamed_and_removed_lints)]
+
 use crate::datamodel::{PfId, ProductFootprint};
 use chrono::{DateTime, Utc};
 use okapi::openapi3::Responses;

--- a/endpoint/src/auth.rs
+++ b/endpoint/src/auth.rs
@@ -4,6 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the crate's root directory of this source tree.
  */
+
+#![allow(renamed_and_removed_lints)]
+
 use jsonwebtoken::errors::Result;
 use jsonwebtoken::TokenData;
 use jsonwebtoken::{DecodingKey, EncodingKey};


### PR DESCRIPTION
Disabled the `renamed_and_removed_lints` lint rule from the two files where it would complain that the `private_in_public` lint has been replaced.

Alternatively, we can replace `cargo clippy -- -D warnings` with `cargo clippy -- -D warnings -A renamed_and_removed_lints` in the `test.yml`.